### PR TITLE
Support IntelliJ 2022.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.sumologic'
-version '1.0.1'
+version '1.0.2'
 
 repositories {
     mavenCentral()
@@ -16,7 +16,7 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = '2021.3'
+    version = '2022.1'
     plugins = ['com.intellij.java']
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '0.4.21'
+    id 'org.jetbrains.intellij' version '1.5.3'
 }
 
 group 'com.sumologic'
@@ -16,8 +16,8 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2021.3'
-    plugins 'com.intellij.java'
+    version = '2021.3'
+    plugins = ['com.intellij.java']
 }
 
 prepareSandbox { from "$rootDir/plugins" }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -21,6 +21,10 @@
             </thead>
             <tbody>
                 <tr>
+                    <td>1.0.2</td>
+                    <td>Updated IntelliJ IDEA dependency</td>
+                </tr>
+                <tr>
                     <td>1.0.1</td>
                     <td>Updated IntelliJ IDEA dependency</td>
                 </tr>


### PR DESCRIPTION
###### Description

Update dependencies + update `org.jetbrains.intellij` gradle plugin.
The new version is already released and awaiting approval: https://plugins.jetbrains.com/plugin/18510-sumo-logic-wordspec/versions